### PR TITLE
Fixed DOMException factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parallel-universe",
-  "version": "1.1.0",
+  "version": "1.1.1-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "parallel-universe",
-      "version": "1.1.0",
+      "version": "1.1.1-next.0",
       "license": "MIT",
       "dependencies": {
         "@smikhalevski/event-bus": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-universe",
-  "version": "1.1.0",
+  "version": "1.1.1-next.0",
   "description": "The set of async flow control structures and promise utils.",
   "main": "./lib/index-cjs.js",
   "module": "./lib/index.js",

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,18 +1,19 @@
-function createError(name: string, message?: string): Error {
+function createError(name: string, code: number, message?: string): Error {
   if (typeof DOMException !== 'undefined') {
     return new DOMException(message, name);
   }
-  const error = new Error(message);
+  const error: any = new Error(message);
   error.name = name;
+  error.code = code;
   return error;
 }
 
 export function createAbortError(): Error {
-  return createError('AbortError');
+  return createError('AbortError', 20);
 }
 
 export function createTimeoutError(): Error {
-  return createError('TimeoutError');
+  return createError('TimeoutError', 23);
 }
 
 export function callOrGet<T, A extends unknown[]>(value: ((...args: A) => T) | T, ...args: A): T {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,23 +1,18 @@
-interface Exception extends Error {
-
-  // https://developer.mozilla.org/en-US/docs/Web/API/DOMException/code
-  code?: number;
+function createError(name: string, message?: string): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException(message, name);
+  }
+  const error = new Error(message);
+  error.name = name;
+  return error;
 }
 
-const Exception: new() => Exception = typeof DOMException !== 'undefined' ? DOMException : Error;
-
-export function createAbortError(): Exception {
-  const ex = new Exception();
-  ex.name = 'AbortError';
-  ex.code = 20;
-  return ex;
+export function createAbortError(): Error {
+  return createError('AbortError');
 }
 
-export function createTimeoutError(): Exception {
-  const ex = new Exception();
-  ex.name = 'TimeoutError';
-  ex.code = 23;
-  return ex;
+export function createTimeoutError(): Error {
+  return createError('TimeoutError');
 }
 
 export function callOrGet<T, A extends unknown[]>(value: ((...args: A) => T) | T, ...args: A): T {


### PR DESCRIPTION
`name` property of `DOMException` instance is readonly in JSDOM:

```ts
new DOMException().name = 'AbortError'; // → throws an error
```