### PR TITLE
Added untilTruthy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,4 +7,5 @@ export * from './isPromiseLike';
 export * from './repeatUntil';
 export * from './sleep';
 export * from './timeout';
+export * from './untilTruthy';
 export * from './shared-types';

--- a/src/main/untilTruthy.ts
+++ b/src/main/untilTruthy.ts
@@ -1,0 +1,28 @@
+import { repeatUntil } from './repeatUntil';
+import { AsyncResult, Awaitable } from './shared-types';
+
+type Falsy = 0 | '' | false | null | undefined;
+
+/**
+ * Returns a promise that is fulfilled when a callback returns a truthy value, or a promise that is fulfilled with a
+ * truthy value.
+ *
+ * @param cb The callback that is periodically invoked.
+ * @param ms The number of milliseconds between the settlement of the last promise returned by the `cb` and the next
+ * invocation. Or a callback that receives the latest result and returns the delay. If omitted then delay is 0.
+ * @param signal The optional signal that instantly aborts the loop. If `signal` was aborted then returned promise is
+ * rejected with [`AbortError`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#aborterror).
+ * @template T The value returned by the callback.
+ * @returns The truthy value.
+ */
+export function untilTruthy<T>(
+  cb: (signal: AbortSignal) => Awaitable<T>,
+  ms?: ((result: AsyncResult<T>) => number) | number | null,
+  signal?: AbortSignal | null
+): Promise<Exclude<T, Falsy>> {
+  return repeatUntil(cb, isTruthyFulfilled, ms, signal);
+}
+
+function isTruthyFulfilled<T>(result: AsyncResult<T>): result is AsyncResult<Exclude<T, Falsy>> {
+  return result.rejected || Boolean(result.result);
+}

--- a/src/test/untilTruthy.test.ts
+++ b/src/test/untilTruthy.test.ts
@@ -1,0 +1,84 @@
+import { untilTruthy } from '../main';
+import { newAbortError } from '../main/utils';
+
+describe('untilTruthy', () => {
+  test('aborts if an aborted signal is provided', async () => {
+    const cbMock = jest.fn();
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(untilTruthy(cbMock, 0, abortController.signal)).rejects.toEqual(newAbortError());
+    expect(cbMock).not.toHaveBeenCalled();
+  });
+
+  test('aborts when signal is aborted', async () => {
+    const cbMock = jest.fn();
+    const abortController = new AbortController();
+
+    const promise = untilTruthy(cbMock, 0, abortController.signal);
+
+    abortController.abort();
+
+    await expect(promise).rejects.toEqual(newAbortError());
+
+    expect(cbMock).toHaveBeenCalled();
+  });
+
+  test('first callback invocation in synchronous', () => {
+    const cbMock = jest.fn();
+
+    untilTruthy(cbMock);
+
+    expect(cbMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects if callback throws synchronously', async () => {
+    await expect(
+      untilTruthy(() => {
+        throw 'foo';
+      })
+    ).rejects.toEqual('foo');
+  });
+
+  test('resolves with returned value', async () => {
+    await expect(untilTruthy(() => 'foo')).resolves.toEqual('foo');
+  });
+
+  test('resolves if callback returns a fulfilled Promise', async () => {
+    await expect(untilTruthy(() => Promise.resolve('foo'))).resolves.toEqual('foo');
+  });
+
+  test('rejects if callback returns rejected Promise', async () => {
+    await expect(untilTruthy(() => Promise.reject('foo'))).rejects.toEqual('foo');
+  });
+
+  test('rejects if delay callback throws', async () => {
+    await expect(
+      untilTruthy(
+        () => false,
+        () => {
+          throw 'bar';
+        }
+      )
+    ).rejects.toEqual('bar');
+  });
+
+  test('passes result to delay callback on resolve', async () => {
+    const cbMock = jest.fn();
+    const delayMock = jest.fn();
+
+    cbMock.mockImplementationOnce(() => 0);
+    cbMock.mockImplementationOnce(() => true);
+
+    await untilTruthy(cbMock, delayMock);
+
+    expect(delayMock).toHaveBeenCalledTimes(1);
+    expect(delayMock).toHaveBeenCalledWith({
+      settled: true,
+      fulfilled: true,
+      rejected: false,
+      result: 0,
+      reason: undefined,
+    });
+  });
+});


### PR DESCRIPTION
Added `untilTruthy` helper that wraps `repeatUntil` and allows waiting until a value returned from a callback becomes truthy.